### PR TITLE
:bug: Add processor flags back to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PROJECT_NAME} main.cpp newlib.cpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 target_compile_options(${PROJECT_NAME} PRIVATE ${CORTEX_M4F_FLAGS})
-target_link_options(${PROJECT_NAME} PRIVATE -T libhal-lpc40xx/lpc4078.ld)
+target_link_options(${PROJECT_NAME} PRIVATE ${CORTEX_M4F_FLAGS}
+  -T libhal-lpc40xx/lpc4078.ld)
 target_link_libraries(${PROJECT_NAME} PRIVATE libhal::lpc40xx)
 arm_cortex_post_build(${PROJECT_NAME})

--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ main()
   static hal::cortex_m::dwt_counter steady_clock(cpu_frequency);
 
   // Get an output pin to use as the LED pin control
-  auto& led_pin = hal::lpc40xx::output_pin::get<1, 18>().value();
+  auto& led_pin = hal::lpc40xx::output_pin::get<1, 10>().value();
 
   while (true) {
     (void)led_pin.level(true);


### PR DESCRIPTION
- Also change the LED to be P1[10] which is the LED on the lpc4078 micromod board.