### PR TITLE
:arrow_up: Bump lpc40 version to ^1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "Default to Debug Build")
+endif(NOT DEFINED CMAKE_BUILD_TYPE)
+
+set(CMAKE_TOOLCHAIN_FILE conan_toolchain.cmake)
+
 project(project_name.elf VERSION 0.0.1 LANGUAGES CXX)
 
 find_package(libhal-lpc40xx REQUIRED CONFIG)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-libhal-lpc40xx/0.3.5
+libhal-lpc40xx/[^1.0.0]
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@ main()
   auto& led_pin = hal::lpc40xx::output_pin::get<1, 10>().value();
 
   while (true) {
+    // (void) is used here to get the compiler to ignore the return values.
     (void)led_pin.level(true);
     (void)hal::delay(steady_clock, 500ms);
     (void)led_pin.level(false);


### PR DESCRIPTION
- :technologist: Remove the need for users to have to supply CMAKE_BUILD_TYPE and CMAKE_TOOLCHAIN_FILE on command line.