### PR TITLE
:technologist: Add warnings & debug info flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(${PROJECT_NAME}
     main.cpp
     application.cpp
     platforms/${platform}.cpp)
+target_compile_options(${PROJECT_NAME} PRIVATE -g -Wall -Wextra)
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 target_link_libraries(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
- `-g` will enable debug info in the .elf file to make debugging the program easier
- `-Wall -Wextra` will provide warnings for common mistakes in the code